### PR TITLE
Update Talk.jsx

### DIFF
--- a/src/components/Views/Talk.jsx
+++ b/src/components/Views/Talk.jsx
@@ -5,9 +5,9 @@ import { When } from '@plone/volto/components/theme/View/EventDatesInfo';
 
 const TalkView = ({ content }) => {
   const color_mapping = {
-    Beginner: 'green',
-    Advanced: 'yellow',
-    Professional: 'purple',
+    beginner: 'green',
+    advanced: 'yellow',
+    professional: 'purple',
   };
 
   return (


### PR DESCRIPTION
Color mapping doesn't render correctly.

<img width="359" alt="Screenshot 2024-03-18 at 4 54 39 PM" src="https://github.com/collective/volto-ploneconf/assets/25995514/c617bf0a-56b9-46e0-957d-1edbd4946b2d">


changing keys to **lower case** fixes the problem.

